### PR TITLE
feat: implement authentication microservice

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "auth-clinica-capurro-backend",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "sqlite3": "^5.1.6",
+    "uuid": "^9.0.0",
+    "passport": "^0.6.0",
+    "passport-google-oauth20": "^2.0.0"
+  }
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,32 @@
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
+
+function decryptPassword(encrypted) {
+  const [ivHex, contentHex] = encrypted.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const content = Buffer.from(contentHex, 'hex');
+  const key = crypto.createHash('sha256').update(String(process.env.PASSWORD_SECRET)).digest();
+  const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
+  const decrypted = Buffer.concat([decipher.update(content), decipher.final()]);
+  return decrypted.toString();
+}
+
+function generateToken(user) {
+  return jwt.sign({ id: user.id, email: user.email, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+}
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ message: 'Missing Authorization header' });
+  const [scheme, token] = authHeader.split(' ');
+  if (scheme !== 'Bearer' || !token) return res.status(401).json({ message: 'Invalid Authorization header' });
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+module.exports = { decryptPassword, generateToken, authMiddleware };

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,61 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbPath = path.join(__dirname, '..', 'auth.db');
+const db = new sqlite3.Database(dbPath);
+
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE,
+    password TEXT,
+    role TEXT,
+    resetToken TEXT
+  )`);
+});
+
+module.exports = {
+  getUserByEmail(email) {
+    return new Promise((resolve, reject) => {
+      db.get(`SELECT * FROM users WHERE email = ?`, [email], (err, row) => {
+        if (err) reject(err); else resolve(row);
+      });
+    });
+  },
+
+  createUser(user) {
+    return new Promise((resolve, reject) => {
+      const { id, email, password, role } = user;
+      db.run(`INSERT INTO users (id, email, password, role) VALUES (?, ?, ?, ?)`,
+        [id, email, password, role], function (err) {
+          if (err) reject(err); else resolve();
+        });
+    });
+  },
+
+  updatePassword(id, password) {
+    return new Promise((resolve, reject) => {
+      db.run(`UPDATE users SET password = ?, resetToken = NULL WHERE id = ?`,
+        [password, id], function (err) {
+          if (err) reject(err); else resolve();
+        });
+    });
+  },
+
+  setResetToken(id, token) {
+    return new Promise((resolve, reject) => {
+      db.run(`UPDATE users SET resetToken = ? WHERE id = ?`,
+        [token, id], function (err) {
+          if (err) reject(err); else resolve();
+        });
+    });
+  },
+
+  getUserByResetToken(token) {
+    return new Promise((resolve, reject) => {
+      db.get(`SELECT * FROM users WHERE resetToken = ?`, [token], (err, row) => {
+        if (err) reject(err); else resolve(row);
+      });
+    });
+  }
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const { v4: uuidv4 } = require('uuid');
+const db = require('../db');
+const { decryptPassword, generateToken, authMiddleware } = require('../auth');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  const { email, password, role } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Missing email or password' });
+  try {
+    const existing = await db.getUserByEmail(email);
+    if (existing) return res.status(409).json({ message: 'User already exists' });
+    const plain = decryptPassword(password);
+    const hash = await bcrypt.hash(plain, 10);
+    const user = { id: uuidv4(), email, password: hash, role: role || 'user' };
+    await db.createUser(user);
+    res.status(201).json({ email: user.email, role: user.role });
+  } catch (err) {
+    res.status(500).json({ message: 'Registration failed' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) return res.status(400).json({ message: 'Missing email or password' });
+  try {
+    const user = await db.getUserByEmail(email);
+    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+    const plain = decryptPassword(password);
+    const ok = await bcrypt.compare(plain, user.password || '');
+    if (!ok) return res.status(401).json({ message: 'Invalid credentials' });
+    const token = generateToken(user);
+    res.json({ email: user.email, token, role: user.role });
+  } catch (err) {
+    res.status(500).json({ message: 'Login failed' });
+  }
+});
+
+router.post('/change-password', authMiddleware, async (req, res) => {
+  const { password } = req.body;
+  if (!password) return res.status(400).json({ message: 'Missing password' });
+  try {
+    const plain = decryptPassword(password);
+    const hash = await bcrypt.hash(plain, 10);
+    await db.updatePassword(req.user.id, hash);
+    res.json({ message: 'Password updated' });
+  } catch (err) {
+    res.status(500).json({ message: 'Change password failed' });
+  }
+});
+
+router.post('/forgot-password', async (req, res) => {
+  const { email } = req.body;
+  if (!email) return res.status(400).json({ message: 'Missing email' });
+  try {
+    const user = await db.getUserByEmail(email);
+    if (!user) return res.json({ message: 'If that account exists, a reset token has been generated' });
+    const token = uuidv4();
+    await db.setResetToken(user.id, token);
+    res.json({ message: 'Password reset initiated', resetToken: token });
+  } catch (err) {
+    res.status(500).json({ message: 'Forgot password failed' });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const { v4: uuidv4 } = require('uuid');
+const authRoutes = require('./routes/auth');
+const { generateToken } = require('./auth');
+const db = require('./db');
+
+passport.use(new GoogleStrategy({
+  clientID: process.env.GOOGLE_CLIENT_ID || '',
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+  callbackURL: '/oauth/google/callback'
+}, async (accessToken, refreshToken, profile, done) => {
+  try {
+    const email = profile.emails[0].value;
+    let user = await db.getUserByEmail(email);
+    if (!user) {
+      user = { id: uuidv4(), email, password: null, role: 'user' };
+      await db.createUser(user);
+    }
+    done(null, user);
+  } catch (err) {
+    done(err);
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use(passport.initialize());
+app.use('/', authRoutes);
+
+app.get('/oauth/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+app.get('/oauth/google/callback', passport.authenticate('google', { session: false, failureRedirect: '/login' }), (req, res) => {
+  const token = generateToken(req.user);
+  res.json({ email: req.user.email, token, role: req.user.role });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add Express server with login, register, password management, and Google OAuth endpoints
- handle encrypted passwords with AES decryption
- store users and roles in SQLite database and issue JWTs

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcryptjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a251936950832484182488dc5b7d37