### PR TITLE
Load dotenv and validate critical environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+JWT_SECRET=your-jwt-secret
+PASSWORD_SECRET=your-password-secret
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=your-db-user
+DB_PASSWORD=your-db-password
+DB_NAME=your-db-name
+PORT=3000

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"No tests specified\" && exit 0"
   },
   "dependencies": {
+    "dotenv": "^16.4.5",
     "bcryptjs": "^2.4.3",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,18 +1,19 @@
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
+const { passwordSecret, jwtSecret } = require('./config');
 
 function decryptPassword(encrypted) {
   const [ivHex, contentHex] = encrypted.split(':');
   const iv = Buffer.from(ivHex, 'hex');
   const content = Buffer.from(contentHex, 'hex');
-  const key = crypto.createHash('sha256').update(String(process.env.PASSWORD_SECRET)).digest();
+  const key = crypto.createHash('sha256').update(String(passwordSecret)).digest();
   const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
   const decrypted = Buffer.concat([decipher.update(content), decipher.final()]);
   return decrypted.toString();
 }
 
 function generateToken(user) {
-  return jwt.sign({ id: user.id, email: user.email, role: user.role }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  return jwt.sign({ id: user.id, email: user.email, role: user.role }, jwtSecret, { expiresIn: '1h' });
 }
 
 function authMiddleware(req, res, next) {
@@ -21,7 +22,7 @@ function authMiddleware(req, res, next) {
   const [scheme, token] = authHeader.split(' ');
   if (scheme !== 'Bearer' || !token) return res.status(401).json({ message: 'Invalid Authorization header' });
   try {
-    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    const payload = jwt.verify(token, jwtSecret);
     req.user = payload;
     next();
   } catch (err) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,32 @@
+const required = [
+  'GOOGLE_CLIENT_ID',
+  'GOOGLE_CLIENT_SECRET',
+  'JWT_SECRET',
+  'PASSWORD_SECRET',
+  'DB_HOST',
+  'DB_PORT',
+  'DB_USER',
+  'DB_PASSWORD',
+  'DB_NAME'
+];
+
+for (const name of required) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+}
+
+module.exports = {
+  googleClientId: process.env.GOOGLE_CLIENT_ID,
+  googleClientSecret: process.env.GOOGLE_CLIENT_SECRET,
+  jwtSecret: process.env.JWT_SECRET,
+  passwordSecret: process.env.PASSWORD_SECRET,
+  db: {
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    name: process.env.DB_NAME
+  },
+  port: process.env.PORT || 3000
+};

--- a/src/db.js
+++ b/src/db.js
@@ -1,13 +1,14 @@
 const { Pool } = require('pg');
+const { db: dbConfig } = require('./config');
 
 // Create a connection pool using environment variables for configuration.
 // Required variables: DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME
 const pool = new Pool({
-  host: process.env.DB_HOST,
-  port: process.env.DB_PORT,
-  user: process.env.DB_USER,
-  password: process.env.DB_PASSWORD,
-  database: process.env.DB_NAME
+  host: dbConfig.host,
+  port: dbConfig.port,
+  user: dbConfig.user,
+  password: dbConfig.password,
+  database: dbConfig.name
 });
 
 // Initialize the schema if it does not exist.

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+const config = require('./config');
 const express = require('express');
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
@@ -7,8 +9,8 @@ const { generateToken } = require('./auth');
 const db = require('./db');
 
 passport.use(new GoogleStrategy({
-  clientID: process.env.GOOGLE_CLIENT_ID || '',
-  clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
+  clientID: config.googleClientId,
+  clientSecret: config.googleClientSecret,
   callbackURL: '/oauth/google/callback'
 }, async (accessToken, refreshToken, profile, done) => {
   try {
@@ -35,5 +37,5 @@ app.get('/oauth/google/callback', passport.authenticate('google', { session: fal
   res.json({ email: req.user.email, token, role: req.user.role });
 });
 
-const PORT = process.env.PORT || 3000;
+const PORT = config.port;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- Add `dotenv` dependency
- Load env vars at server start and centralize validation in new `config` module
- Document required environment variables via `.env.example`

## Testing
- `npm test`
- `npm install dotenv@16` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68a50209ec688324acff150dcfa1071f