### PR TITLE
Accept plain text passwords over HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 JWT_SECRET=your-jwt-secret
-PASSWORD_SECRET=your-password-secret
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=your-db-user

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,16 +1,5 @@
-const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
-const { passwordSecret, jwtSecret } = require('./config');
-
-function decryptPassword(encrypted) {
-  const [ivHex, contentHex] = encrypted.split(':');
-  const iv = Buffer.from(ivHex, 'hex');
-  const content = Buffer.from(contentHex, 'hex');
-  const key = crypto.createHash('sha256').update(String(passwordSecret)).digest();
-  const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
-  const decrypted = Buffer.concat([decipher.update(content), decipher.final()]);
-  return decrypted.toString();
-}
+const { jwtSecret } = require('./config');
 
 function generateToken(user) {
   return jwt.sign({ id: user.id, email: user.email, role: user.role }, jwtSecret, { expiresIn: '1h' });
@@ -30,4 +19,4 @@ function authMiddleware(req, res, next) {
   }
 }
 
-module.exports = { decryptPassword, generateToken, authMiddleware };
+module.exports = { generateToken, authMiddleware };

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,6 @@ const required = [
   'GOOGLE_CLIENT_ID',
   'GOOGLE_CLIENT_SECRET',
   'JWT_SECRET',
-  'PASSWORD_SECRET',
   'DB_HOST',
   'DB_PORT',
   'DB_USER',
@@ -20,7 +19,6 @@ module.exports = {
   googleClientId: process.env.GOOGLE_CLIENT_ID,
   googleClientSecret: process.env.GOOGLE_CLIENT_SECRET,
   jwtSecret: process.env.JWT_SECRET,
-  passwordSecret: process.env.PASSWORD_SECRET,
   db: {
     host: process.env.DB_HOST,
     port: process.env.DB_PORT,

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -2,9 +2,17 @@ const express = require('express');
 const bcrypt = require('bcryptjs');
 const { v4: uuidv4 } = require('uuid');
 const db = require('../db');
-const { decryptPassword, generateToken, authMiddleware } = require('../auth');
+const { generateToken, authMiddleware } = require('../auth');
 
 const router = express.Router();
+
+// Ensure authentication routes are accessed over HTTPS
+router.use((req, res, next) => {
+  if (req.secure || req.headers['x-forwarded-proto'] === 'https') {
+    return next();
+  }
+  res.status(400).json({ message: 'HTTPS required' });
+});
 
 router.post('/register', async (req, res) => {
   const { email, password, role } = req.body;
@@ -12,8 +20,7 @@ router.post('/register', async (req, res) => {
   try {
     const existing = await db.getUserByEmail(email);
     if (existing) return res.status(409).json({ message: 'User already exists' });
-    const plain = decryptPassword(password);
-    const hash = await bcrypt.hash(plain, 10);
+    const hash = await bcrypt.hash(password, 10);
     const user = { id: uuidv4(), email, password: hash, role: role || 'user' };
     await db.createUser(user);
     res.status(201).json({ email: user.email, role: user.role });
@@ -28,8 +35,7 @@ router.post('/login', async (req, res) => {
   try {
     const user = await db.getUserByEmail(email);
     if (!user) return res.status(401).json({ message: 'Invalid credentials' });
-    const plain = decryptPassword(password);
-    const ok = await bcrypt.compare(plain, user.password || '');
+    const ok = await bcrypt.compare(password, user.password || '');
     if (!ok) return res.status(401).json({ message: 'Invalid credentials' });
     const token = generateToken(user);
     res.json({ email: user.email, token, role: user.role });
@@ -42,8 +48,7 @@ router.post('/change-password', authMiddleware, async (req, res) => {
   const { password } = req.body;
   if (!password) return res.status(400).json({ message: 'Missing password' });
   try {
-    const plain = decryptPassword(password);
-    const hash = await bcrypt.hash(plain, 10);
+    const hash = await bcrypt.hash(password, 10);
     await db.updatePassword(req.user.id, hash);
     res.json({ message: 'Password updated' });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Allow auth routes to accept plain text passwords and enforce HTTPS usage
- Remove obsolete password decryption logic and password secret configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5051683d0832483f7ce627d8dcc4d