### PR TITLE
feat: add validation middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.4.5",
     "bcryptjs": "^2.4.3",
     "express": "^4.18.2",
+    "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.1",
     "uuid": "^9.0.0",

--- a/src/middleware/validation.js
+++ b/src/middleware/validation.js
@@ -1,0 +1,11 @@
+const { validationResult } = require('express-validator');
+
+module.exports = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      errors: errors.array().map(err => err.msg)
+    });
+  }
+  next();
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -6,6 +6,8 @@ const { generateToken, authMiddleware } = require('../auth');
 const nodemailer = require('nodemailer');
 const crypto = require('crypto');
 const config = require('../config');
+const { body } = require('express-validator');
+const validate = require('../middleware/validation');
 
 const router = express.Router();
 
@@ -17,58 +19,99 @@ router.use((req, res, next) => {
   res.status(400).json({ message: 'HTTPS required' });
 });
 
-router.post('/register', async (req, res) => {
-  const { email, password, role } = req.body;
-  if (!email || !password) return res.status(400).json({ message: 'Missing email or password' });
-  try {
-    const existing = await db.getUserByEmail(email);
-    if (existing) return res.status(409).json({ message: 'User already exists' });
-    const hash = await bcrypt.hash(password, 10);
-    const user = { id: uuidv4(), email, password: hash, role: role || 'user' };
-    await db.createUser(user);
-    res.status(201).json({ email: user.email, role: user.role });
-  } catch (err) {
-    res.status(500).json({ message: 'Registration failed' });
+router.post(
+  '/register',
+  [
+    body('email').isEmail().withMessage('Invalid email'),
+    body('password')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters long')
+      .matches(/[A-Za-z]/)
+      .withMessage('Password must contain letters')
+      .matches(/[0-9]/)
+      .withMessage('Password must contain numbers'),
+    validate
+  ],
+  async (req, res) => {
+    const { email, password, role } = req.body;
+    try {
+      const existing = await db.getUserByEmail(email);
+      if (existing) return res.status(409).json({ message: 'User already exists' });
+      const hash = await bcrypt.hash(password, 10);
+      const user = { id: uuidv4(), email, password: hash, role: role || 'user' };
+      await db.createUser(user);
+      res.status(201).json({ email: user.email, role: user.role });
+    } catch (err) {
+      res.status(500).json({ message: 'Registration failed' });
+    }
   }
-});
+);
 
-router.post('/login', async (req, res) => {
-  const { email, password } = req.body;
-  if (!email || !password) return res.status(400).json({ message: 'Missing email or password' });
-  try {
-    const user = await db.getUserByEmail(email);
-    if (!user) return res.status(401).json({ message: 'Invalid credentials' });
-    const ok = await bcrypt.compare(password, user.password || '');
-    if (!ok) return res.status(401).json({ message: 'Invalid credentials' });
-    const token = generateToken(user);
-    res.json({ email: user.email, token, role: user.role });
-  } catch (err) {
-    res.status(500).json({ message: 'Login failed' });
+router.post(
+  '/login',
+  [
+    body('email').isEmail().withMessage('Invalid email'),
+    body('password')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters long')
+      .matches(/[A-Za-z]/)
+      .withMessage('Password must contain letters')
+      .matches(/[0-9]/)
+      .withMessage('Password must contain numbers'),
+    validate
+  ],
+  async (req, res) => {
+    const { email, password } = req.body;
+    try {
+      const user = await db.getUserByEmail(email);
+      if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+      const ok = await bcrypt.compare(password, user.password || '');
+      if (!ok) return res.status(401).json({ message: 'Invalid credentials' });
+      const token = generateToken(user);
+      res.json({ email: user.email, token, role: user.role });
+    } catch (err) {
+      res.status(500).json({ message: 'Login failed' });
+    }
   }
-});
+);
 
-router.post('/change-password', authMiddleware, async (req, res) => {
-  const { password } = req.body;
-  if (!password) return res.status(400).json({ message: 'Missing password' });
-  try {
-    const hash = await bcrypt.hash(password, 10);
-    await db.updatePassword(req.user.id, hash);
-    res.json({ message: 'Password updated' });
-  } catch (err) {
-    res.status(500).json({ message: 'Change password failed' });
+router.post(
+  '/change-password',
+  authMiddleware,
+  [
+    body('password')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters long')
+      .matches(/[A-Za-z]/)
+      .withMessage('Password must contain letters')
+      .matches(/[0-9]/)
+      .withMessage('Password must contain numbers'),
+    validate
+  ],
+  async (req, res) => {
+    const { password } = req.body;
+    try {
+      const hash = await bcrypt.hash(password, 10);
+      await db.updatePassword(req.user.id, hash);
+      res.json({ message: 'Password updated' });
+    } catch (err) {
+      res.status(500).json({ message: 'Change password failed' });
+    }
   }
-});
+);
 
-router.post('/forgot-password', async (req, res) => {
-  const { email } = req.body;
-  if (!email) return res.status(400).json({ message: 'Missing email' });
-  try {
-    const user = await db.getUserByEmail(email);
-    if (!user) return res.json({ message: 'If that account exists, a reset email has been sent' });
-    const token = uuidv4();
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
-    const expiresAt = new Date(Date.now() + 3600000);
-    await db.setResetToken(user.id, tokenHash, expiresAt);
+router.post(
+  '/forgot-password',
+  [body('email').isEmail().withMessage('Invalid email'), validate],
+  async (req, res) => {
+    const { email } = req.body;
+    try {
+      const user = await db.getUserByEmail(email);
+      if (!user) return res.json({ message: 'If that account exists, a reset email has been sent' });
+      const token = uuidv4();
+      const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+      const expiresAt = new Date(Date.now() + 3600000);
+      await db.setResetToken(user.id, tokenHash, expiresAt);
 
     try {
       if (config.email && config.email.host) {
@@ -94,17 +137,30 @@ router.post('/forgot-password', async (req, res) => {
   } catch (err) {
     res.status(500).json({ message: 'Forgot password failed' });
   }
-});
+  }
+);
 
-router.post('/reset-password', async (req, res) => {
-  const { token, password } = req.body;
-  if (!token || !password) return res.status(400).json({ message: 'Missing token or password' });
-  try {
-    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
-    const user = await db.getUserByResetToken(tokenHash);
-    if (!user || !user.resetTokenExpiry) {
-      return res.status(400).json({ message: 'Invalid or expired token' });
-    }
+router.post(
+  '/reset-password',
+  [
+    body('token').notEmpty().withMessage('Token is required'),
+    body('password')
+      .isLength({ min: 8 })
+      .withMessage('Password must be at least 8 characters long')
+      .matches(/[A-Za-z]/)
+      .withMessage('Password must contain letters')
+      .matches(/[0-9]/)
+      .withMessage('Password must contain numbers'),
+    validate
+  ],
+  async (req, res) => {
+    const { token, password } = req.body;
+    try {
+      const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+      const user = await db.getUserByResetToken(tokenHash);
+      if (!user || !user.resetTokenExpiry) {
+        return res.status(400).json({ message: 'Invalid or expired token' });
+      }
     if (new Date(user.resetTokenExpiry) < new Date()) {
       await db.clearResetToken(user.id);
       return res.status(400).json({ message: 'Invalid or expired token' });
@@ -115,6 +171,7 @@ router.post('/reset-password', async (req, res) => {
   } catch (err) {
     res.status(500).json({ message: 'Reset password failed' });
   }
-});
+  }
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add express-validator dependency
- centralize validation error handling
- validate email format and password strength on auth routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a50c1f91508324b59002e1281bb498