### PR TITLE
Add helmet and cors security middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,28 @@ export DB_NAME=mydatabase
 Configure these variables in your production environment so the API can connect
 to the correct database instance.
 
+## Security configuration
+
+The server uses [helmet](https://github.com/helmetjs/helmet) and
+[cors](https://github.com/expressjs/cors) for basic security hardening.
+
+### CORS origins
+
+Allowed origins can be specified via the `CORS_ORIGINS` environment variable.
+Provide a comma-separated list of origins when `NODE_ENV=production`.
+During development all origins are allowed by default.
+
+Example configuration:
+
+```bash
+# Development
+export NODE_ENV=development
+
+# Production
+export NODE_ENV=production
+export CORS_ORIGINS=https://app.example.com,https://admin.example.com
+```
+
+Adjust these variables for each environment to control who can access the API
+and to fine-tune security headers.
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "uuid": "^9.0.0",
     "passport": "^0.6.0",
     "passport-google-oauth20": "^2.0.0",
-    "nodemailer": "^6.9.8"
+    "nodemailer": "^6.9.8",
+    "helmet": "^7.0.0",
+    "cors": "^2.8.5"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,8 @@
 require('dotenv').config();
 const config = require('./config');
 const express = require('express');
+const helmet = require('helmet');
+const cors = require('cors');
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const { v4: uuidv4 } = require('uuid');
@@ -27,6 +29,13 @@ passport.use(new GoogleStrategy({
 }));
 
 const app = express();
+
+const allowedOrigins = process.env.NODE_ENV === 'production' && process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',')
+  : '*';
+
+app.use(helmet());
+app.use(cors({ origin: allowedOrigins }));
 app.use(express.json());
 app.use(passport.initialize());
 app.use('/', authRoutes);


### PR DESCRIPTION
## Summary
- add helmet and cors dependencies
- enable Helmet and CORS middleware with environment-based origin list
- document security configuration and environment-specific CORS settings

## Testing
- `npm test`
- `npm install helmet cors` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a511059dcc83248a0f37a03e63432f