### PR TITLE
feat: fetch configuration from aws secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ DB_USER=your-db-user
 DB_PASSWORD=your-db-password
 DB_NAME=your-db-name
 PORT=3000
+AWS_REGION=us-east-1
+SECRET_ID=your-secret-id

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ export DB_NAME=mydatabase
 Configure these variables in your production environment so the API can connect
 to the correct database instance.
 
+## AWS Secrets Manager
+
+In production you can store sensitive configuration in [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
+
+1. Create a secret containing keys such as `DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME` and `JWT_SECRET`.
+2. Attach an IAM role to the EC2 instance that allows `secretsmanager:GetSecretValue`.
+3. Set `AWS_REGION` and `SECRET_ID` environment variables on the instance. `SECRET_ID` should match the name or ARN of the secret you created.
+
+At startup the app uses the AWS SDK to retrieve the secret and populate `process.env` before launching the server. Local development can still use a traditional `.env` file.
+
 ## Security configuration
 
 The server uses [helmet](https://github.com/helmetjs/helmet) and

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "main": "src/server.js",
   "type": "commonjs",
   "scripts": {
-    "start": "node src/server.js",
+    "start": "node src/start.js",
     "test": "node --test"
   },
   "dependencies": {
+    "aws-sdk": "^2.1692.0",
     "dotenv": "^16.4.5",
     "bcryptjs": "^2.4.3",
     "express": "^4.18.2",

--- a/src/start.js
+++ b/src/start.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+const AWS = require('aws-sdk');
+
+async function loadSecrets() {
+  const secretId = process.env.SECRET_ID;
+  if (!secretId) return;
+  const region = process.env.AWS_REGION;
+  const client = new AWS.SecretsManager({ region });
+  const data = await client.getSecretValue({ SecretId: secretId }).promise();
+  if (data.SecretString) {
+    const secrets = JSON.parse(data.SecretString);
+    Object.assign(process.env, secrets);
+  }
+}
+
+async function start() {
+  try {
+    await loadSecrets();
+    const app = require('./server');
+    const config = require('./config');
+    const PORT = config.port;
+    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
+  } catch (err) {
+    console.error('Failed to start server:', err);
+    process.exit(1);
+  }
+}
+
+start();


### PR DESCRIPTION
## Summary
- load runtime configuration from AWS Secrets Manager via new start script
- document Secrets Manager usage and required environment variables

## Testing
- `npm test`
- `npm install aws-sdk` *(fails: 403 Forbidden - GET https://registry.npmjs.org/aws-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68a5294b18f88324a120be0c9da80ec7